### PR TITLE
Add protocol name (needed by IE11)

### DIFF
--- a/markdown/guide/deploying-engines.md
+++ b/markdown/guide/deploying-engines.md
@@ -8,7 +8,7 @@ var app = new EmberApp(defaults, {
   assetLoader: {
     generateURI: function(filePath) {
       if (EmberApp.env() === 'production') {
-        return '//production.cdn.com/' + filePath;
+        return 'https://production.cdn.com/' + filePath;
       } else {
         return 'local/static/' + filePath;
       }


### PR DESCRIPTION
It appears that if you don't specify the protocol name, IE11 will just concatenate the URI to the original host name.