### PR TITLE
Allow usage of newer ember versions

### DIFF
--- a/markdown/guide/creating-an-engine.md
+++ b/markdown/guide/creating-an-engine.md
@@ -33,7 +33,7 @@ Next, we need to install the proper version of Ember for use with ember-engines.
 
 ```bash
 rm -rf bower_components/ember
-bower install --save ember#2.10.0
+bower install --save ember#^2.10.0
 ```
 
 For other versions, check out the [compatibility information in the readme](https://github.com/dgeb/ember-engines/blob/master/README.md#important-note-about-compatibility-and-stability).


### PR DESCRIPTION
#2.10.0 means we lock to _specifically_ 2.10.0. It's better to allow e.g. 2.11 and 2.12 to be installed by using the ^ character here.