### PR TITLE
link-to doesn't work without a second parameter

### DIFF
--- a/markdown/guide/linking-and-external-links.md
+++ b/markdown/guide/linking-and-external-links.md
@@ -83,7 +83,7 @@ _Note that the Engine name, which is normally dasherized, is camel-cased here in
 You can use these external routes within your Engine via the `{{link-to-external}}` component:
 
 ```hbs
-{{link-to-external "home"}}
+{{link-to-external "home" "home"}}
 ```
 
 Or, one of the programmatic APIs, such as `Route#transitionToExternal` and `Route#replaceWithExternal`:

--- a/markdown/guide/linking-and-external-links.md
+++ b/markdown/guide/linking-and-external-links.md
@@ -83,7 +83,7 @@ _Note that the Engine name, which is normally dasherized, is camel-cased here in
 You can use these external routes within your Engine via the `{{link-to-external}}` component:
 
 ```hbs
-{{link-to-external "home" "home"}}
+{{link-to-external "Go home" "home"}}
 ```
 
 Or, one of the programmatic APIs, such as `Route#transitionToExternal` and `Route#replaceWithExternal`:


### PR DESCRIPTION
If you use a link-to without "yield", you have to provide two parameters:
- name of the route
- text to show

So the example of `{{link-to-external "home"}}` won't work until you give one more parameter:
`{{link-to-external "home" "home"}}`
