### PR TITLE
Add addon info

### DIFF
--- a/app/styles/_markdown.scss
+++ b/app/styles/_markdown.scss
@@ -9,11 +9,17 @@
 
   & > ul,
   & > ol {
-    margin-left: 1rem;
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+
+    & ul,
+    & ol {
+      margin-left: 1.5rem;
+    }
   }
 
   & li {
-    margin-bottom: 1rem;
+    margin-bottom: 0.2rem;
   }
 
   & > h2,

--- a/lib/guide/addon/utils/table-of-contents.js
+++ b/lib/guide/addon/utils/table-of-contents.js
@@ -8,6 +8,7 @@ export default [
   { page: 'services', title: 'Sharing Services' },
   { page: 'sharing-components-and-more', title: 'Sharing Components and More' },
   { page: 'lazy-loading', title: 'Lazy Loading' },
+  { page: 'addons', title: 'Engines & Addons' },
   { page: 'deploying-engines', title: 'Deploying An Engine' },
   { page: 'testing', title: 'Testing'}
 ];

--- a/markdown/guide/addons.md
+++ b/markdown/guide/addons.md
@@ -1,0 +1,85 @@
+## Engines & Addons
+
+If you want to use an addon in an engine, you have to add it to the engines `dependencies`. This is necessary for the following types of addons:
+
+* Addons that provide components or helpers that you want to use in the engine
+* Addons that provide other utils or similar that you want to use in the engine
+* Addons that provide services that are not passed through from the host app
+
+The following types of addons should be placed in the `devDependencies`:
+
+* Addons that provide services that are passed through from the host app
+* Addons that do build adaptions
+
+### Using Ember Data
+
+When working with Ember Data, the models are defined in the host app, and you will need to pass the `store` service through to the engine as a dependency. This way, the host app and the engine use the same store and models. You then need to add `ember-data` as a `devDependency` to your engine.
+
+The easiest way to realise this is to define your models in a shared addon, which is included by both your host app and your engine. 
+
+### Addon deduplication
+
+ember-engines will automatically try to deduplicate addons used by your host app and (lazy loaded) engine(s). This means that addons that both the host app and an engine rely on, are only included in the vendor bundle of the host app. This ensures that you do not ship the addon code multiple times to your users.
+
+If addons are not included in the host app, they will be included in the engine's vendor bundle. 
+
+Note that the deduplication between host app and addon depends on the `cacheKeyForTree()` method of the addon. It will only deduplicate if the cache key returned by that method is the same. This will by default be the case, unless the addon provides a custom `treeForAddon()` hook. If that is the case, the addon should provide a custom `cacheKeyForTree()` method that returns a static key - for example:
+
+```js
+const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
+
+module.exports = {
+  name: require('./package').name,
+
+  treeForAddon() {
+    // returns custom tree - overwriting this hook disables the default caching!
+  },
+
+  cacheKeyForTree(treeType) {
+    if (treeType === 'addon') {
+      return calculateCacheKeyForTree(treeType, this);
+    }
+
+    return this._super.cacheKeyForTree.apply(this, arguments);
+  }
+};
+```
+
+### Managing multiple addon versions
+
+When working with engines, it is important to avoid including different versions of the same addon. Currently, only one addon version can actually be loaded at a time. If your host app and engines depend on different versions of an addon, you will run into hard to control issues.
+ 
+ For example, imagine the host app depends on `ember-power-select^1.0.0`, engine-a depends on `ember-power-select~2.0.0` and engine-b depends on `ember-power-select~2.1.0`.
+ 
+ Now, three different versions of ember-power-select would be included in the respective vendor bundles. But which version would actually be used in your app/engine would depend on the order in which the bundles are loaded. 
+ 
+ Generally, you should ensure that only one version of a given addon is included across your host app and engines. A  great way to ensure this is to use [ember-cli-dependency-lint](https://github.com/salsify/ember-cli-dependency-lint), which will tell you if multiple versions of an addon are installed.
+ 
+ If you use Yarn, you can use [resolutions](https://yarnpkg.com/lang/en/docs/selective-version-resolutions/) to force a specific version to be used by an addon. In the above example, you could add the following to your host apps `package.json`:
+ 
+ ```json
+{
+  "dependencies": {},
+  "devDependencies": {},
+  "resolutions": {
+    "**/ember-power-select": "^1.0.0"
+  }
+}
+```
+
+This would force this version on all addons. Please use this feature with caution, as it is then up to you to make sure that all apps and engines actually work with this version of the addon.
+
+### Using Yarn workspaces
+
+One way to work with engines is to use [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/). You could set up your app like this:
+
+* `my-app` (workspace)
+  * `packages`
+    * `host-app`
+    * `engine-a`
+    * `engine-b`
+    * `shared-addon`
+   
+In this example, the actual app would be in the `my-app/packages/host-app` directory, while `my-app/packages/engine-a` and `my-app/packages/engine-b` would be engines. `my-app/packages/shared-addon` could be a shared addon that is used by the host app & all engines, including for example common components, services or Ember Data models. 
+
+The advantage of this approach is that all of these dependencies will always be in sync and up to date. If you change something in the shared addon, it will immediately be reflected in the host app and all engines. It also makes it easier to ensure all engines depend on the same versions of addons. 


### PR DESCRIPTION
This adds an "Addon" section with information about how to include addons, addon deduplication and how to manage version conflicts.

Fixes #16 and https://github.com/ember-engines/ember-engines/issues/606