### PR TITLE
Use and document correct `lazyLoading.enabled` invocation.

### DIFF
--- a/lib/guide/index.js
+++ b/lib/guide/index.js
@@ -7,8 +7,7 @@ module.exports = EngineAddon.extend({
     return true;
   },
 
-  // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
-  lazyLoading: {
+  lazyLoading: Object.freeze({
     enabled: true
-  }
+  })
 });

--- a/lib/guide/index.js
+++ b/lib/guide/index.js
@@ -7,5 +7,8 @@ module.exports = EngineAddon.extend({
     return true;
   },
 
-  lazyLoading: true
+  // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
+  lazyLoading: {
+    enabled: true
+  }
 });

--- a/markdown/guide/creating-an-engine.md
+++ b/markdown/guide/creating-an-engine.md
@@ -85,11 +85,13 @@ const EngineAddon = require('ember-engines/lib/engine-addon');
 
 module.exports = EngineAddon.extend({
   name: 'ember-blog',
-  lazyLoading: false
+  lazyLoading: {
+    enabled: false
+  }
 });
 ```
 
-We'll leave the `lazyLoading` flag as `false` for now, as we'll be discussing the topic of lazy-loading engines in depth later on in this guide.
+We'll leave the `lazyLoading.enabled` flag as `false` for now, as we'll be discussing the topic of lazy-loading engines in depth later on in this guide.
 
 Within your Engine's `config` directory, modify the `environment.js` file:
 


### PR DESCRIPTION
Per [the current implementation][src], the correct invocation is not a boolean but an object with `enabled: boolean` on it. This PR updates both the engine itself and the guides to match that.

[src]: https://github.com/ember-engines/ember-engines/blob/1265ad153f724c531da5e42df47c52fc9f9c71da/lib/engine-addon.js#L384:L390