### PR TITLE
Adding command to generate routes for in-repo engine

### DIFF
--- a/markdown/guide/creating-an-engine.md
+++ b/markdown/guide/creating-an-engine.md
@@ -207,6 +207,18 @@ lib/foo/addon/components/awesome-sauce.js
 lib/foo/addon/templates/components/awesome-sauce.hbs
 tests/integration/components/awesome-sauce-test.js
 ```
+#### Remove from in-repo engines
+For removing the above generated routes (components and other things) from your engine, replace `generate` with `destroy` in the shell command
+
+Removing a route from an in-repo engine: 
+```shell
+ember destroy route <route-name> --in-repo <in-repo-name>
+``` 
+
+Removing a component from an in-repo engine: 
+```shell
+ember destroy component <component-name> --in-repo <in-repo-name>
+``` 
 
 ---
 

--- a/markdown/guide/creating-an-engine.md
+++ b/markdown/guide/creating-an-engine.md
@@ -212,5 +212,9 @@ export default buildRoutes(function() {
   });
 });
 ```
+To create a route within an in-repo-engine, you can run
+```shell
+ember generate route <route-name> --in-repo <in-repo-name>
+``` 
 
 In the next section, we'll see how this route map gets merged into the host route map. So, let's go!

--- a/markdown/guide/creating-an-engine.md
+++ b/markdown/guide/creating-an-engine.md
@@ -179,6 +179,37 @@ Observant developers might also note that Addon's have an `app` directory in add
 
 ---
 
+### Generate in an in-repo Engine
+
+Using the right flags, generating routes, components (etc) in an in-repo engine is the same as in a regular Ember application.
+
+To create a route within an in-repo-engine, you can run:
+```shell
+ember generate route <route-name> --in-repo <in-repo-name>
+``` 
+
+To create a component within an in-repo-engine, you can run:
+```shell
+ember generate component <component-name> --in-repo <in-repo-name>
+``` 
+
+To generate helpers, controllers and other things, you can use the `--in-repo` flag like above.
+
+#### Using the --in flag
+As of ember-cli@3.7 and higher the generate command includes an `--in` flag that allows you to specify the directory to generate into.
+For example, given an in-repo addon at lib/my-foo/:
+```shell
+ember generate component awesome-sauce --in ./lib/foo
+``` 
+Will generate the following files: 
+```shell
+lib/foo/addon/components/awesome-sauce.js
+lib/foo/addon/templates/components/awesome-sauce.hbs
+tests/integration/components/awesome-sauce-test.js
+```
+
+---
+
 ### Adding Routes for Routable Engines
 
 At this point, if you're building a Route-less Engine, then you're done and can skip ahead to the "[Mounting An Engine](./mounting-engines)" section. If, however, you're building a Routable Engine, then you need to create one more file:
@@ -212,9 +243,5 @@ export default buildRoutes(function() {
   });
 });
 ```
-To create a route within an in-repo-engine, you can run
-```shell
-ember generate route <route-name> --in-repo <in-repo-name>
-``` 
 
 In the next section, we'll see how this route map gets merged into the host route map. So, let's go!

--- a/markdown/guide/creating-an-engine.md
+++ b/markdown/guide/creating-an-engine.md
@@ -43,6 +43,47 @@ If you want to share elements between an in-repo engine and application, you cou
 }
 ```
 
+#### Generate in an In-Repo-Engine
+
+Using the right flags, generating routes, components (etc) in an in-repo engine is the same as in a regular Ember application.
+
+To create a route within an in-repo-engine, you can run:
+```shell
+ember generate route <route-name> --in-repo <in-repo-name>
+``` 
+
+To create a component within an in-repo-engine, you can run:
+```shell
+ember generate component <component-name> --in-repo <in-repo-name>
+``` 
+
+To generate helpers, controllers and other things, you can use the `--in-repo` flag like above.
+
+#### Using the --in flag
+As of ember-cli@3.7 and higher the generate command includes an `--in` flag that allows you to specify the directory to generate into.
+For example, given an in-repo addon at lib/my-foo/:
+```shell
+ember generate component awesome-sauce --in ./lib/foo
+``` 
+Will generate the following files: 
+```shell
+lib/foo/addon/components/awesome-sauce.js
+lib/foo/addon/templates/components/awesome-sauce.hbs
+tests/integration/components/awesome-sauce-test.js
+```
+#### Remove from In-Repo-Engine
+For removing the above generated routes (components and other things) from your engine, replace `generate` with `destroy` in the shell command
+
+Removing a route from an in-repo engine: 
+```shell
+ember destroy route <route-name> --in-repo <in-repo-name>
+``` 
+
+Removing a component from an in-repo engine: 
+```shell
+ember destroy component <component-name> --in-repo <in-repo-name>
+``` 
+
 ### Create as Addon
 
 Separate addon projects can be created with the addon command:
@@ -176,49 +217,6 @@ Engines achieve code isolation.
 As long as the `modulePrefix` for your application doesn't match the `name` of an Addon, then your application won't be able to resolve modules living in your Addon. This is why it is important that Engines have their own `Resolver` with a separate `modulePrefix` that matches the Addon's `name`.
 
 Observant developers might also note that Addon's have an `app` directory in addition to their `addon` directory. The `app` directory from an Addon gets merged into the host's namespace. This allows Addons to "re-export" modules from their own namespace into the namespace of the consumer so that they can be used as if part of the host. Engines, however, should never re-export modules into their host, and so anything placed into the `app` directory of an Engine Addon will not be included in the build.
-
----
-
-### Generate in an in-repo Engine
-
-Using the right flags, generating routes, components (etc) in an in-repo engine is the same as in a regular Ember application.
-
-To create a route within an in-repo-engine, you can run:
-```shell
-ember generate route <route-name> --in-repo <in-repo-name>
-``` 
-
-To create a component within an in-repo-engine, you can run:
-```shell
-ember generate component <component-name> --in-repo <in-repo-name>
-``` 
-
-To generate helpers, controllers and other things, you can use the `--in-repo` flag like above.
-
-#### Using the --in flag
-As of ember-cli@3.7 and higher the generate command includes an `--in` flag that allows you to specify the directory to generate into.
-For example, given an in-repo addon at lib/my-foo/:
-```shell
-ember generate component awesome-sauce --in ./lib/foo
-``` 
-Will generate the following files: 
-```shell
-lib/foo/addon/components/awesome-sauce.js
-lib/foo/addon/templates/components/awesome-sauce.hbs
-tests/integration/components/awesome-sauce-test.js
-```
-#### Remove from in-repo engines
-For removing the above generated routes (components and other things) from your engine, replace `generate` with `destroy` in the shell command
-
-Removing a route from an in-repo engine: 
-```shell
-ember destroy route <route-name> --in-repo <in-repo-name>
-``` 
-
-Removing a component from an in-repo engine: 
-```shell
-ember destroy component <component-name> --in-repo <in-repo-name>
-``` 
 
 ---
 


### PR DESCRIPTION
Adding the `ember generate route <route-name> --in-repo <in-repo-name>` command in the documentation (under the section *Adding Routes for Routable Engines*) to help ease onboarding for new-comers.