### PR TITLE
Update the note about devDependency and peerDependency

### DIFF
--- a/markdown/guide/creating-an-engine.md
+++ b/markdown/guide/creating-an-engine.md
@@ -112,7 +112,7 @@ cd super-blog/
 ember install ember-engines
 ```
 
-A quick note, Engines should have `ember-engines` listed as a `devDependency` or `peerDependency`. The reason for this is that if you include `ember-engines` as a `dependency` of both the host application and the Engine, you'll wind up duplicating some crucial functionality which can cause problems. Therefore, it is best that the host application provide the copy to be used.
+A quick note, Engines should have `ember-engines` listed as a `devDependency` and `peerDependency`. The reason for this is that if you include `ember-engines` as a `dependency` of both the host application and the Engine, you'll wind up duplicating some crucial functionality which can cause problems. Therefore, it is best that the host application provide the copy to be used.
 
 Finally, we need to ensure `ember-cli-htmlbars` is listed as a dependency for compiling our templates:
 


### PR DESCRIPTION
The previous note was wrong: listing `ember-engines` in the engine's `peerDependency` does not allow the engine to be built locally.

I believe `ember-engines` should be listed in **both** `devDependencies` and `peerDependencies`:

1. it is needed in `devDependencies` for the build to succeed
2. it is needed in `peerDependencies`
    - to avoid avoid the `node/no-unpublished-require` error when doing `const EngineAddon = require('ember-engines/lib/engine-addon');`
    - to show that the consuming app of this engine also needs to reference `ember-engines`

I agree that point `2` is not crucial, but I believe it would better represent why `ember-engines` is needed inside an engine's `package.json`.