### PR TITLE
[docs] fixes fingerprinting in docs and also fixes markdown on main landing page

### DIFF
--- a/tests/dummy/app/templates/docs/index.md
+++ b/tests/dummy/app/templates/docs/index.md
@@ -6,11 +6,11 @@ On a technical level, engines and applications are remarkably similar: they each
 
 The often used example of this is a "blogging" application. While a blog itself could be a full-fledged application, you may also wish to use it as a specific subsection of your overall application. If you threw a "news feed" engine into that mix, you might get an application structure that looks something like this:
 
-<img src="/images/app-engine-diagram.jpeg" alt="Diagram of Application with two Engines" width="850" />
+<img src="/images/app-engine-diagram.jpeg" alt="Diagram of Application with two Engines" width="850">
 
 This host application relies upon Engines to control different "zones" of functionality. However, from the user's perspective, the host application and its engines appear to be a single application.
 
-# Why use Engines?
+## Why use Engines?
 
 Large organizations often use Ember.js to power sophisticated web applications. These apps may require collaboration among several teams, sometimes distributed around the world. Typically, responsibility is shared by dividing the application into one or more "sections". How this division is actually implemented varies from team to team.
 

--- a/tests/dummy/app/templates/docs/lazy-loading.md
+++ b/tests/dummy/app/templates/docs/lazy-loading.md
@@ -69,7 +69,7 @@ Beyond that it adds in a configuration module for the engine, and nothing else. 
 
 # Lazy Engines
 
-Lazy engines are built in the same way as eager engines, but their assets are not combined back into the host application's `vendor.js` file. This means that they are run through a separate and unique build process from what a default addon will go through, though it reaches out to the upstream implementation in Ember CLI where possible.
+Lazy engines are built in the same way as eager engines, but their assets are not combined back into the host application's `vendor-{hash}.js` file. This means that they are run through a separate and unique build process from what a default addon will go through, though it reaches out to the upstream implementation in Ember CLI where possible.
 
 A lazy engine's output (`lazy-engine`) looks like this:
 
@@ -78,15 +78,15 @@ dist
 ├── assets
 │   ├── host-application.css
 │   ├── host-application.js
-│   ├── vendor.css
-│   └── vendor.js
+│   ├── vendor-{hash}.css
+│   └── vendor-{hash}.js
 ├── engines-dist
 │   └── lazy-engine
 |       ├── config
 │       |   ├── enviroment.js
 │       ├── assets
-│       │   ├── engine-vendor.css
-│       │   ├── engine-vendor.js
+│       │   ├── engine-vendor-{hash}.css
+│       │   ├── engine-vendor-{hash}.js
 │       │   ├── engine.css
 │       │   └── engine.js
 │       └── public-asset.jpg


### PR DESCRIPTION
fixes #89 

# Finger printing

## before

<img width="1792" alt="Screen Shot 2020-04-07 at 1 54 19 PM" src="https://user-images.githubusercontent.com/1854811/78718837-d0868500-78d7-11ea-9013-6a0931e0f386.png">

## after

<img width="1792" alt="Screen Shot 2020-04-07 at 1 54 03 PM" src="https://user-images.githubusercontent.com/1854811/78718844-d3817580-78d7-11ea-8791-8e3f4279260e.png">

# markdown formatting on landing page

The issue with this was that the `img` was closed and the markdown interpreter assumes img takes are self closing. ie (valid) `<img>` (invalid) `<img/>`.

## before

<img width="1792" alt="Screen Shot 2020-04-07 at 1 56 51 PM" src="https://user-images.githubusercontent.com/1854811/78718870-e005ce00-78d7-11ea-9c98-495b91dc9370.png">

## after

<img width="1792" alt="Screen Shot 2020-04-07 at 1 56 43 PM" src="https://user-images.githubusercontent.com/1854811/78718882-e3995500-78d7-11ea-8f38-8b5bca2b9600.png">
