### PR TITLE
[docs] adds bundling docs and discusses dependency mismatches

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function() {
     this.route('deploying');
 
     this.route('dependencies');
+    this.route('bundling');
     this.route('isolation');
     this.route('routable-vs-routeless');
     this.route('addons');

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -8,6 +8,7 @@
 
     {{nav.section "Core Concepts"}}
     {{nav.item "Dependencies" "docs.dependencies"}}
+    {{nav.item "Bundling" "docs.bundling"}}
     {{nav.item "Isolation" "docs.isolation"}}
     {{nav.item "Routable vs. Routeless" "docs.routable-vs-routeless"}}
     {{nav.item "Lazy loading" "docs.lazy-loading"}}

--- a/tests/dummy/app/templates/docs/bundling.md
+++ b/tests/dummy/app/templates/docs/bundling.md
@@ -4,11 +4,12 @@ _Ember Engines_ not only provides isolation principles for how your code is run,
 
 ## Host / Engine Dependencies
 
-In the following example, if the dependency required by the _Engine A_ is different than the _Host_ it will resolve the top level dependency. In this case `Foo` will resolve to `Foo@2`. If that dependency is not in the host and only in the Engine, it will be bundled in `engine-vendor-{hash}.js`.
+In the following example, if the dependency required by the _Engine A_ is different than the _Host_ it will resolve the top level dependency. In this case `Foo` will resolve to `Foo@2`. If that dependency is not in the host and only in the Engine, it will be bundled in `engine-vendor-{hash}.js`. For the case of `Baz`, since both _Engine A_ and the _Host_ require the same dependency it will be bundled into `vendor-{hash}.js` and will be deduped out of the `engine-vendor-{hash}.js` output.
 
 ```
 | Dependency Name | Engine A | Host |
 |=================|==========|======|
 | Foo             | v2       | v1   |
 | Bar             | v1       | N\A  |
+| Baz             | v2       | v2   |
 ```

--- a/tests/dummy/app/templates/docs/bundling.md
+++ b/tests/dummy/app/templates/docs/bundling.md
@@ -1,0 +1,14 @@
+# Bundling
+
+_Ember Engines_ not only provides isolation principles for how your code is run, but also how it is bundled.
+
+## Host / Engine Dependencies
+
+In the following example, if the dependency required by the _Engine A_ is different than the _Host_ it will resolve the top level dependency. In this case `Foo` will resolve to `Foo@2`. If that dependency is not in the host and only in the Engine, it will be bundled in `engine-vendor-{hash}.js`.
+
+```
+| Dependency Name | Engine A | Host |
+|=================|==========|======|
+| Foo             | v2       | v1   |
+| Bar             | v1       | N\A  |
+```


### PR DESCRIPTION
*Why?*

I think it is important to discuss how engines works so that way when engineers are deciding how to structure their engines it will be obvious of what the outcomes should be.

<img width="1792" alt="Screen Shot 2020-04-09 at 8 44 17 PM" src="https://user-images.githubusercontent.com/1854811/78960431-e8f6cb00-7aa2-11ea-8221-d190c0b6ec2e.png">

fixes #60 