### PR TITLE
[styling] fixes the default styling as that has been removed from ember-cli-addon-docs

### DIFF
--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -8,6 +8,14 @@
   padding: 0 1.5rem;
 }
 
+.docs-md ul {
+  list-style: disc;
+}
+
+.docs-md ol {
+  list-style: decimal;
+}
+
 @media only screen and (min-width: 40.0625em) {
   h1,
   h2,

--- a/tests/dummy/app/templates/docs/bundling.md
+++ b/tests/dummy/app/templates/docs/bundling.md
@@ -4,7 +4,7 @@ _Ember Engines_ not only provides isolation principles for how your code is run,
 
 ## Host / Engine Dependencies
 
-In the following example:
+In the following examples:
 
 - If the dependency required by the _Engine A_ is different than the _Host_ it will resolve the top level dependency. In this case `Foo` will resolve to `Foo@2`.
 


### PR DESCRIPTION
fixes #95 

<img width="1792" alt="Screen Shot 2020-05-03 at 11 07 45 AM" src="https://user-images.githubusercontent.com/1854811/80921976-c5841080-8d2e-11ea-8bfe-30d073d008ef.png">

# Motivation

This has always worked as expected, we just needed to opt-in to the styles wanted to set as defaults. 