### PR TITLE
Move doc examples to ember octane

### DIFF
--- a/tests/dummy/app/templates/docs/lazy-loading.md
+++ b/tests/dummy/app/templates/docs/lazy-loading.md
@@ -34,7 +34,7 @@ For example, if you had a `Post` route defined like so:
 ```js
 import Route from "@ember/routing/route";
 
-export default Route.extend({
+export default class PostRoute extends Route {
   serialize(model) {
     return { post_id: model.id };
   }

--- a/tests/dummy/app/templates/docs/links.md
+++ b/tests/dummy/app/templates/docs/links.md
@@ -29,7 +29,7 @@ Previously we mentioned that each Engine has it's own `application` route, that 
 Or, maybe even:
 
 ```hbs
-<LinkTo @route="index">Also goes to Blog Hom</LinkTo>
+<LinkTo @route="index">Also goes to Blog Home</LinkTo>
 ```
 
 It's a little confusing at first, but the gist is to think of the route paths as if the Engine were it's own application.

--- a/tests/dummy/app/templates/docs/links.md
+++ b/tests/dummy/app/templates/docs/links.md
@@ -9,13 +9,13 @@ Within a routable Engine, route paths are relative to the Engine's "mount point"
 In other words, if you're trying to go to route `super-blog.posts.index`, you might do the following from the host application:
 
 ```hbs
-{{#link-to "super-blog.posts.index"}}Comments{{/link-to}}
+<LinkTo @route="super-blog.posts.index">Comments</LinkTo>
 ```
 
 However, if you are inside the `super-blog` Engine, you would need to do the following:
 
 ```hbs
-{{#link-to "posts.index"}}Comments{{/link-to}}
+<LinkTo @route="posts.index">Comments</LinkTo>
 ```
 
 Notice that the `super-blog` portion of the path is now missing, this is because that is the Engine's mount point.
@@ -23,13 +23,13 @@ Notice that the `super-blog` portion of the path is now missing, this is because
 Previously we mentioned that each Engine has it's own `application` route, that route corresponds to the mount point when within the Engine. So, if you wanted to go to `super-blog` (or the root of the Engine) from within the Engine itself, you would do something like:
 
 ```hbs
-{{#link-to "application"}}Goes to Blog Home{{/link-to}}
+<LinkTo @route="application">Goes to Blog Home</LinkTo>
 ```
 
 Or, maybe even:
 
 ```hbs
-{{#link-to "index"}}Also goes to Blog Home{{/link-to}}
+<LinkTo @route="index">Also goes to Blog Hom</LinkTo>
 ```
 
 It's a little confusing at first, but the gist is to think of the route paths as if the Engine were it's own application.
@@ -44,15 +44,15 @@ In order to deal with this, Engines allow you to specify external routes as depe
 
 ```js
 // super-blog/addon/engine.js
-export default Engine.extend({
+export default class SuperBlog extends Engine {
   // ...
-  dependencies: {
+  dependencies = {
     externalRoutes: [
       'home',
       'settings'
     ]
-  }
-});
+  };
+}
 ```
 
 External routes define things that your Engine needs to link to. The host is then responsible for telling you where those things are. In other words, the Engine defines _what_ it would like to go to and the application tells it _where_ that is.
@@ -65,39 +65,43 @@ So, when you mount your Engine, you'll need to make sure the host specifies appr
 // dummy/app/app.js
 import Application from '@ember/application';
 
-const App = Application.extend({
+export default class App extends Application {
   // ...
-  engines: {
-    superBlog: {
-      dependencies: {
-        externalRoutes: {
-          home: 'home.index',
-          settings: 'settings.blog.index'
+  constructor() {
+    super(...arguments);
+
+    this.engines = {
+      superBlog: {
+        dependencies: {
+          externalRoutes: {
+            home: 'home.index',
+            settings: 'settings.blog.index'
+          }
         }
       }
     }
   }
-});
+}
 ```
 
 _Note that the Engine name, which is normally dasherized, is camel-cased here instead._
 
-You can use these external routes within your Engine via the `{{link-to-external}}` component:
+You can use these external routes within your Engine via the `<LinkToExternal/>` component:
 
 ```hbs
-{{link-to-external "Go home" "home"}}
+<LinkToExternal @route="home">Go Home</LinkToExternal>
 ```
 
 Or, one of the programmatic APIs, such as `Route#transitionToExternal` and `Route#replaceWithExternal`:
 
 ```js
 import Route from "@ember/routing/route";
+import { action } from '@ember/object';
 
-export default Route.extend({
-  actions: {
-    goHome() {
-      this.transitionToExternal('home');
-    }
+export default class YourRoute extends Route {
+  @action
+  goHome() {
+    this.transitionToExternal('home');
   }
 });
 ```

--- a/tests/dummy/app/templates/docs/quickstart.md
+++ b/tests/dummy/app/templates/docs/quickstart.md
@@ -177,21 +177,21 @@ Next, add the following code to `engine.js`:
 
 ```js
 // addon/engine.js
+import Engine from '@ember/engine';
 
-import Engine from 'ember-engines/engine';
-import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
 import config from './config/environment';
 
 const { modulePrefix } = config;
-const Eng = Engine.extend({
-  modulePrefix,
-  Resolver
-});
 
-loadInitializers(Eng, modulePrefix);
+export default class YourEngine extends Engine {
+  modulePrefix = modulePrefix;
+  Resolver = Resolver;
+}
 
-export default Eng;
+loadInitializers(YourEngine, modulePrefix);
 ```
 
 This code will look familiar to anyone that's seen an Ember Application's `app.js` file before. Since Engines are so closely related to Applications, it makes sense that their initial files look similar.
@@ -224,7 +224,7 @@ Observant developers might also note that Addon's have an `app` directory in add
 
 ## Adding Routes for Routable Engines
 
-At this point, if you're building a Route-less Engine, then you're done and can skip ahead to the "[Mounting An Engine](./mounting-engines)" section. If, however, you're building a Routable Engine, then you need to create one more file:
+At this point, if you're building a Route-less Engine, then you're done and can skip ahead to the "[Mounting An Engine](#mounting-an-engine)" section. If, however, you're building a Routable Engine, then you need to create one more file:
 
 ```shell
 touch addon/routes.js

--- a/tests/dummy/app/templates/docs/services.md
+++ b/tests/dummy/app/templates/docs/services.md
@@ -4,9 +4,9 @@ In addition to external routes, you can also specify Services as dependencies of
 
 ```js
 // super-blog/addon/engine.js
-export default Engine.extend({
+export default class YourEngine extends Engine {
   // ...
-  dependencies: {
+  dependencies = {
     services: [
       'store',
       'session'
@@ -19,21 +19,23 @@ This means that your Engine will expect the host application to provide both the
 
 ```js
 // dummy/app/app.js
-import Application from '@ember/application';
-
-const App = Application.extend({
+export default class App extends Application {
   // ...
-  engines: {
-    superBlog: {
-      dependencies: {
-        services: [
-          'store',
-          { 'session': 'user-session' }
-        ]
+  constructor() {
+    super(...arguments);
+
+    this.engines = {
+      superBlog: {
+        dependencies: {
+          services: [
+            'store',
+            { 'session': 'user-session' }
+          ]
+        }
       }
     }
   }
-});
+}
 ```
 
 In this example, the host provides its `store` service for the Engine's `store`. The Engine's `session` service, however, is actually the `user-session` service of the host. Thus, you can provide a re-mapping of service names by using an object instead of a simple string.

--- a/tests/dummy/app/templates/docs/testing-acceptance.md
+++ b/tests/dummy/app/templates/docs/testing-acceptance.md
@@ -140,14 +140,16 @@ module('basic acceptance test', function(hooks) {
   setupApplicationTest(hooks);
 
   test('the user can click on the home button and trigger external transition', async function(assert) {
-    const transitionToExternal = (actual) => {
-      let expected = 'home';
-      assert.equal(actual, expected);
-    });
-    const router = Service.extend({ transitionToExternal });
-  
     this.owner.unregister('service:router');
-    this.owner.register('service:router', router);
+    this.owner.register(
+      'service:router',
+      class extends Service {
+        transitionToExternal(actual) {
+          let expected = 'home';
+          assert.equal(actual, expected);
+        }
+      }
+    );
 
     await visit('/');
     await click('.back-to-home');

--- a/tests/dummy/app/templates/docs/testing-unit.md
+++ b/tests/dummy/app/templates/docs/testing-unit.md
@@ -11,13 +11,14 @@ Suppose that we have in the engine a service that has a `computedFoo` computed p
 import Service from '@ember/service';
 import { computed } from '@ember/object';
 
-export default Service.extend({
-  foo: 'bar',
+export default class SomeService extends Service {
+  foo = 'bar';
 
-  computedFoo: computed('foo', function() {
+  @computed('foo')
+  get computedFoo() {
     return `computed ${this.foo}`;
-  })
-});
+  }
+}
 ```
 
 The unit test will be like this:


### PR DESCRIPTION
We're moving the doc examples to Octane version following the official upgrade guide - https://guides.emberjs.com/release/upgrading/current-edition/