### PR TITLE
Remove "re-export addons" from guides

### DIFF
--- a/tests/dummy/app/templates/docs/sharing-code.md
+++ b/tests/dummy/app/templates/docs/sharing-code.md
@@ -6,9 +6,7 @@ For instance, having to provide several route paths and services, such as Ember 
 
 However, there are use cases for needing to share components and more across Engine boundaries. In those instances, the proper solution is to move the shared constructs into an addon.
 
-## Addon Re-exports
-
-Any addon included in your Engine's package.json `dependencies` key will automatically get included in your Engine.
+## Using an Addon
 
 Suppose we have these two addons `common-components` and `payment-graph` to share code between the host app and engine, so we can re-use the common elements and payment graphs within the engine.
 
@@ -18,3 +16,5 @@ Suppose we have these two addons `common-components` and `payment-graph` to shar
   "payment-graph": "0.0.0"
 }
 ```
+
+Any addon included in your Engine's package.json `dependencies` key will automatically get included in your Engine.

--- a/tests/dummy/app/templates/docs/sharing-code.md
+++ b/tests/dummy/app/templates/docs/sharing-code.md
@@ -15,8 +15,6 @@ Suppose we have these two addons `common-components` and `payment-graph` to shar
 ```json
 "dependencies": {
   "common-components": "0.0.0",
-  "payment-graph": "0.0.0",
-  "ember-cli-babel": "^7.19.0",
-  "ember-cli-htmlbars": "^5.1.2"
+  "payment-graph": "0.0.0"
 }
 ```

--- a/tests/dummy/app/templates/docs/sharing-code.md
+++ b/tests/dummy/app/templates/docs/sharing-code.md
@@ -8,25 +8,4 @@ However, there are use cases for needing to share components and more across Eng
 
 ## Addon Re-exports
 
-In order to use things like Components and Helpers from addons in your Engine, they will need to be present in your Engine's namespace. This is accomplished by doing what is called a "re-export":
-
-```js
-//super-blog/app/components/foo-bar.js
-export { default } from 'super-addon/components/foo-bar';
-```
-
-As you can see we're simply exporting the import from `super-addon`. Since we're exporting an export, we call it re-exporting.
-
-As you can imagine, doing this for everything in the addons you need to use could be very tedious. So `ember-engines` provides a simple way to automatically re-export everything an addon usually provides to an application: the `EngineAddon` base class.
-
-The `EngineAddon` base class hooks into Ember-CLI's build hooks to automatically re-export addon code into your Engine. You can add it to your Engine like so:
-
-```js
-// super-blog/index.js
-const EngineAddon = require('ember-engines/lib/engine-addon');
-module.exports = EngineAddon.extend({
-  name: 'super-blog'
-});
-```
-
-That's it! Now, any addon included in your package.json `dependencies` key will automatically get included in your Engine.
+Any addon included in your Engine's `package.json` file will automatically get included in your Engine.

--- a/tests/dummy/app/templates/docs/sharing-code.md
+++ b/tests/dummy/app/templates/docs/sharing-code.md
@@ -8,4 +8,15 @@ However, there are use cases for needing to share components and more across Eng
 
 ## Addon Re-exports
 
-Any addon included in your Engine's `package.json` file will automatically get included in your Engine.
+Any addon included in your Engine's package.json `dependencies` key will automatically get included in your Engine.
+
+Suppose we have these two addons `common-components` and `payment-graph` to share code between the host app and engine, so we can re-use the common elements and payment graphs within the engine.
+
+```json
+"dependencies": {
+  "common-components": "0.0.0",
+  "payment-graph": "0.0.0",
+  "ember-cli-babel": "^7.19.0",
+  "ember-cli-htmlbars": "^5.1.2"
+}
+```

--- a/tests/dummy/app/templates/docs/sharing-code.md
+++ b/tests/dummy/app/templates/docs/sharing-code.md
@@ -5,16 +5,3 @@ For Engines, globally relevant constructs, such as Services and Route paths, mak
 For instance, having to provide several route paths and services, such as Ember Data's Store, creates a relatively easy to fulfill API for consumers of your Engine. If your Engine also required specific components, helpers, and utilities, all needing to conform to the API usage inside your Engine, then you all of a sudden have substantially more coupling involved. This is bad for isolation and does not give you flexibility in developing your Engine independently of your host.
 
 However, there are use cases for needing to share components and more across Engine boundaries. In those instances, the proper solution is to move the shared constructs into an addon.
-
-## Using an Addon
-
-Suppose we have these two addons `common-components` and `payment-graph` to share code between the host app and engine, so we can re-use the common elements and payment graphs within the engine.
-
-```json
-"dependencies": {
-  "common-components": "0.0.0",
-  "payment-graph": "0.0.0"
-}
-```
-
-Any addon included in your Engine's package.json `dependencies` key will automatically get included in your Engine.


### PR DESCRIPTION
It will remove the anti-pattern to embe-engines, because break the isolation

https://ember-engines.com/docs/lazy-loading#-app