### PR TITLE
Start deprecations page with host router service

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -27,6 +27,8 @@ Router.map(function() {
     this.route('testing-acceptance');
 
     this.route('links');
+
+    this.route('deprecations');
   });
 
   // Avoid break the SEO from old website

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -24,6 +24,9 @@
 
     {{nav.section "Components"}}
     {{nav.item "Links" "docs.links"}}
+
+    {{nav.section "Migrating"}}
+    {{nav.item "Deprecations" "docs.deprecations"}}
   {{/viewer.nav}}
 
   {{#viewer.main}}

--- a/tests/dummy/app/templates/docs/deprecations.md
+++ b/tests/dummy/app/templates/docs/deprecations.md
@@ -10,7 +10,7 @@ However, we don't want to automatically create either of these services in an en
 
 In order to migrate, use any other names please:
 
-Bad:
+Before:
 
 ```js
 export default class App extends Application {
@@ -31,7 +31,8 @@ export default class App extends Application {
 }
 
 ```
-Good:
+
+After:
 
 ```js
 export default class App extends Application {

--- a/tests/dummy/app/templates/docs/deprecations.md
+++ b/tests/dummy/app/templates/docs/deprecations.md
@@ -1,0 +1,54 @@
+# Deprecations
+
+### Host router service
+
+**until**: 0.9.0
+
+**id**: ember-engines.deprecation-router-service-from-host
+
+However, we don't want to automatically create either of these services in an engine - the decision should be the developer's.
+
+In order to migrate, use any other names please:
+
+Bad:
+
+```js
+export default class App extends Application {
+  // ...
+  constructor() {
+    super(...arguments);
+
+    this.engines = {
+      superBlog: {
+        dependencies: {
+          services: [
+            'router',
+          ]
+        }
+      }
+    }
+  }
+}
+
+```
+Good:
+
+```js
+export default class App extends Application {
+  // ...
+  constructor() {
+    super(...arguments);
+
+    this.engines = {
+      superBlog: {
+        dependencies: {
+          services: [
+            { 'host-router'}: 'router',
+          ]
+        }
+      }
+    }
+  }
+}
+
+```


### PR DESCRIPTION
Regarding the https://github.com/ember-engines/ember-engines/pull/764 we're adding the Deprecations page to keep the users of Engines up-to-date about everything and keep Ember Engines very well documented.