### PR TITLE
Update test documentation to use new testing syntax.

### DIFF
--- a/tests/dummy/app/templates/docs/testing-integration.md
+++ b/tests/dummy/app/templates/docs/testing-integration.md
@@ -16,17 +16,14 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import engineResolverFor from 'ember-engines/test-support/engine-resolver-for';
-
-const modulePrefix = 'admin-engine';
-const resolver = engineResolverFor(modulePrefix);
+import { setupEngine } from 'ember-engines/test-support';
 
 module('Integration | Component | hello-name', function(hooks) {
-  setupRenderingTest(hooks, { resolver });
+  setupRenderingTest(hooks);
+  setupEngine(hooks, 'admin-engine')
 
   test('it renders', async function(assert) {
-
-    await render(hbs`<HelloName @name="Tom"/>`);
+    await render(hbs`<HelloName @name="Tom"/>`, { owner: this.engine });
 
     assert.equal(this.element.textContent.trim(), 'Hello, Tom!');
   });

--- a/tests/dummy/app/templates/docs/testing-intro.md
+++ b/tests/dummy/app/templates/docs/testing-intro.md
@@ -28,23 +28,17 @@ preloadAssets(manifest).then(start); // This ensures all engine resources are lo
 
 ### Rendering/Unit tests
 
-When you deal with `ember-engines` and you would like to test your engine code (e.g. components and services), you need to make sure that the test environment for your dummy application has access to the engine component and service. To make sure it does, you need to replace the default resolver with a proper engine resolver from an addon:
-
+When you deal with `ember-engines` and you would like to test your engine code (e.g. components and services), you need to make sure that the test environment instantiates the engine. The `setupEngine` helper can be used to automatically load, instantiate, and provide access to the engine.
 
 ```js
 // tests/<integration or unit>/…
-import engineResolverFor from 'ember-engines/test-support/engine-resolver-for';
+import { setupEngine } from 'ember-engines/test-support';
 ```
-To use it, you pass it as a param to your setup call. For instance, in case of unit tests, you replace the default...
+
+To use it, include it in your test module with the name of your engine.
 
 ```js
-setupTest(hooks);
+setupEngine(hooks, '<engine-name>');
 ```
 
-... and use this instead:
-
-```js
-setupTest(hooks, {
-  resolver: engineResolverFor('your-engine-name')
-});
-```
+The engine owner can be accessed in tests through `this.engine`.

--- a/tests/dummy/app/templates/docs/testing-unit.md
+++ b/tests/dummy/app/templates/docs/testing-unit.md
@@ -1,6 +1,6 @@
 # Unit Testing
 
-To test candidates for unit/integration (e.g. components, services and controllers) declared inside an engine, you need to set a custom resolver with the engine's prefix using `engineResolverFor` helper.
+To test candidates for unit/integration (e.g. components, services and controllers) declared inside an engine, you need to set up the engine using the `setupEngine` helper. This helper provides access to the engine in the test environment via `this.engine`.
 
 What does it look like to test a component from a host app or dummy app? Let's go over some examples in the next section. In the following tests, `admin-engine` is an engine, `hello-name` is a component, and `some-thing` is a service. (Note: the same tests will apply whether `admin-engine` is an in-repo or standalone engine).
 
@@ -28,16 +28,14 @@ The unit test will be like this:
 
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import engineResolverFor from 'ember-engines/test-support/engine-resolver-for';
-
-const modulePrefix = 'admin-engine';
-const resolver = engineResolverFor(modulePrefix);
+import { setupEngine } from 'ember-engines/test-support';
 
 module('Unit | Service | some thing', function(hooks) {
-  setupTest(hooks, { resolver });
+  setupTest(hooks);
+  setupEngine(hooks, 'admin-engine')
 
   test('should correctly concat foo', function(assert) {
-    const someThing = this.owner.lookup('service:some-thing');
+    const someThing = this.engine.lookup('service:some-thing');
     someThing.set('foo', 'baz');
 
     assert.equal(someThing.get('computedFoo'), 'computed baz');


### PR DESCRIPTION
The test API for engines was improved in 2022, so we need to update the documentation to reflect the expected testing API: https://github.com/ember-engines/ember-engines/pull/653